### PR TITLE
JWT + 세션 하이브리드 인증 방식 구현

### DIFF
--- a/src/main/java/com/authplayground/api/application/auth/AuthenticationService.java
+++ b/src/main/java/com/authplayground/api/application/auth/AuthenticationService.java
@@ -12,6 +12,7 @@ import com.authplayground.api.domain.member.model.AuthMember;
 import com.authplayground.api.domain.member.repository.BlacklistRepository;
 import com.authplayground.api.domain.member.repository.TokenRepository;
 import com.authplayground.api.dto.auth.request.LoginRequest;
+import com.authplayground.api.dto.auth.response.LoginResponse;
 import com.authplayground.api.dto.token.response.TokenResponse;
 import com.authplayground.global.auth.token.JwtProvider;
 
@@ -29,7 +30,7 @@ public class AuthenticationService {
 	private final BlacklistRepository blacklistRepository;
 
 	@Transactional
-	public TokenResponse loginMember(LoginRequest loginRequest) {
+	public LoginResponse loginMember(LoginRequest loginRequest) {
 		final Member member = memberReadService.getMemberByEmail(loginRequest.email());
 
 		authenticationValidator.validatePasswordMatches(loginRequest.password(), member.getPassword());
@@ -39,7 +40,7 @@ public class AuthenticationService {
 
 		tokenRepository.saveToken(member.getEmail(), refreshToken);
 
-		return new TokenResponse(accessToken, refreshToken);
+		return LoginResponse.of(member, accessToken, refreshToken);
 	}
 
 	@Transactional

--- a/src/main/java/com/authplayground/api/application/auth/AuthenticationService.java
+++ b/src/main/java/com/authplayground/api/application/auth/AuthenticationService.java
@@ -1,7 +1,5 @@
 package com.authplayground.api.application.auth;
 
-import static com.authplayground.global.common.util.JwtConstant.*;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +13,7 @@ import com.authplayground.api.dto.auth.request.LoginRequest;
 import com.authplayground.api.dto.auth.response.LoginResponse;
 import com.authplayground.api.dto.token.response.TokenResponse;
 import com.authplayground.global.auth.token.JwtProvider;
+import com.authplayground.global.common.util.SessionManager;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,9 @@ import lombok.RequiredArgsConstructor;
 public class AuthenticationService {
 
 	private final JwtProvider jwtProvider;
+	private final SessionManager sessionManager;
 	private final AuthenticationValidator authenticationValidator;
+	private final AuthenticationTokenService authenticationTokenService;
 	private final MemberReadService memberReadService;
 	private final TokenRepository tokenRepository;
 	private final BlacklistRepository blacklistRepository;
@@ -45,29 +46,35 @@ public class AuthenticationService {
 
 	@Transactional
 	public void logoutMember(AuthMember authMember, HttpServletRequest httpServletRequest) {
-		final String accessToken = jwtProvider.extractToken(httpServletRequest, AUTHORIZATION_HEADER);
-		final long remaining = jwtProvider.getTokenRemainingTime(accessToken);
+		final String accessToken = authenticationTokenService.extractAccessToken(httpServletRequest);
+		final long remaining = authenticationTokenService.getRemainingAccessTokenTime(accessToken);
 
 		blacklistRepository.registerBlacklist(accessToken, remaining);
 		tokenRepository.deleteTokenByEmail(authMember.email());
+
+		sessionManager.expiredSession(httpServletRequest);
 	}
 
 	@Transactional
 	public TokenResponse reissueToken(HttpServletRequest httpServletRequest) {
-		final String refreshToken = httpServletRequest.getHeader(REFRESH_TOKEN_HEADER);
+		final String accessToken = authenticationTokenService.extractAccessToken(httpServletRequest);
+		final String refreshToken = authenticationTokenService.extractRefreshToken(httpServletRequest);
 
 		authenticationValidator.validateRefreshTokenFormat(refreshToken);
 
-		final AuthMember authMember = jwtProvider.extractAuthMemberFromToken(refreshToken);
+		final AuthMember authMember = authenticationTokenService.parseAuthMember(refreshToken);
+		final String storedRefreshToken = tokenRepository.findTokenByEmail(authMember.email());
+		final long remainingTokenTime = authenticationTokenService.getRemainingAccessTokenTime(accessToken);
+
+		authenticationValidator.validateRefreshTokenReused(storedRefreshToken, refreshToken);
+
+		blacklistRepository.registerBlacklist(accessToken, remainingTokenTime);
+		tokenRepository.deleteTokenByEmail(authMember.email());
+
 		final Member member = memberReadService.getMemberByEmail(authMember.email());
-		final String savedRefreshToken = tokenRepository.findTokenByEmail(member.getEmail());
-
-		authenticationValidator.validateRefreshTokenMatches(refreshToken, savedRefreshToken);
-
 		final String newAccessToken = generateAccessToken(member);
 		final String newRefreshToken = generateRefreshToken(member);
 
-		tokenRepository.deleteTokenByEmail(member.getEmail());
 		tokenRepository.saveToken(member.getEmail(), newRefreshToken);
 
 		return new TokenResponse(newAccessToken, newRefreshToken);

--- a/src/main/java/com/authplayground/api/application/auth/AuthenticationTokenService.java
+++ b/src/main/java/com/authplayground/api/application/auth/AuthenticationTokenService.java
@@ -1,0 +1,34 @@
+package com.authplayground.api.application.auth;
+
+import static com.authplayground.global.common.util.JwtConstant.*;
+
+import org.springframework.stereotype.Service;
+
+import com.authplayground.api.domain.member.model.AuthMember;
+import com.authplayground.global.auth.token.JwtProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationTokenService {
+
+	private final JwtProvider jwtProvider;
+
+	public String extractAccessToken(HttpServletRequest httpServletRequest) {
+		return jwtProvider.extractToken(httpServletRequest, AUTHORIZATION_HEADER);
+	}
+
+	public String extractRefreshToken(HttpServletRequest httpServletRequest) {
+		return httpServletRequest.getHeader(REFRESH_TOKEN_HEADER);
+	}
+
+	public long getRemainingAccessTokenTime(String accessToken) {
+		return jwtProvider.getTokenRemainingTime(accessToken);
+	}
+
+	public AuthMember parseAuthMember(String token) {
+		return jwtProvider.extractAuthMemberFromToken(token);
+	}
+}

--- a/src/main/java/com/authplayground/api/application/auth/validator/AuthenticationValidator.java
+++ b/src/main/java/com/authplayground/api/application/auth/validator/AuthenticationValidator.java
@@ -30,9 +30,9 @@ public class AuthenticationValidator {
 		}
 	}
 
-	public void validateRefreshTokenMatches(String requestToken, String savedToken) {
-		if (!requestToken.equals(savedToken)) {
-			throw new UnauthorizedException(MISMATCH_REFRESH_TOKEN);
+	public void validateRefreshTokenReused(String storedToken, String providedToken) {
+		if (storedToken == null || !storedToken.equals(providedToken)) {
+			throw new UnauthorizedException(REUSED_REFRESH_TOKEN);
 		}
 	}
 }

--- a/src/main/java/com/authplayground/api/dto/auth/response/LoginResponse.java
+++ b/src/main/java/com/authplayground/api/dto/auth/response/LoginResponse.java
@@ -1,0 +1,22 @@
+package com.authplayground.api.dto.auth.response;
+
+import com.authplayground.api.domain.member.entity.Member;
+import com.authplayground.api.domain.member.model.AuthMember;
+import com.authplayground.api.dto.token.response.TokenResponse;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(
+	TokenResponse tokenResponse,
+
+	AuthMember authMember
+) {
+
+	public static LoginResponse of(Member member, String accessToken, String refreshToken) {
+		return new LoginResponse(
+			new TokenResponse(accessToken, refreshToken),
+			new AuthMember(member.getEmail(), member.getNickname(), member.getRole())
+		);
+	}
+}

--- a/src/main/java/com/authplayground/api/presentation/AuthenticationController.java
+++ b/src/main/java/com/authplayground/api/presentation/AuthenticationController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.authplayground.api.application.auth.AuthenticationService;
 import com.authplayground.api.domain.member.model.AuthMember;
 import com.authplayground.api.dto.auth.request.LoginRequest;
+import com.authplayground.api.dto.auth.response.LoginResponse;
 import com.authplayground.api.dto.token.response.TokenResponse;
 import com.authplayground.global.auth.annotation.Auth;
+import com.authplayground.global.common.util.SessionManager;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -21,11 +23,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthenticationController {
 
+	private final SessionManager sessionManager;
 	private final AuthenticationService authenticationService;
 
 	@PostMapping("/login")
-	public ResponseEntity<TokenResponse> loginMember(@RequestBody @Valid LoginRequest loginRequest) {
-		return ResponseEntity.ok().body(authenticationService.loginMember(loginRequest));
+	public ResponseEntity<TokenResponse> loginMember(
+		@RequestBody @Valid LoginRequest loginRequest,
+		HttpServletRequest httpServletRequest) {
+
+		LoginResponse loginResponse = authenticationService.loginMember(loginRequest);
+		sessionManager.saveAuthMember(httpServletRequest, loginResponse.authMember());
+
+		return ResponseEntity.ok().body(loginResponse.tokenResponse());
 	}
 
 	@PostMapping("/logout")

--- a/src/main/java/com/authplayground/global/auth/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/authplayground/global/auth/AuthMemberArgumentResolver.java
@@ -1,0 +1,72 @@
+package com.authplayground.global.auth;
+
+import static com.authplayground.global.error.model.ErrorMessage.*;
+
+import java.util.Optional;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.authplayground.api.domain.member.model.AuthMember;
+import com.authplayground.global.auth.annotation.Auth;
+import com.authplayground.global.common.util.SessionManager;
+import com.authplayground.global.error.exception.UnauthorizedException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final SessionManager sessionManager;
+
+	@Override
+	public boolean supportsParameter(MethodParameter methodParameter) {
+		return methodParameter.hasParameterAnnotation(Auth.class)
+			&& methodParameter.getParameterType().equals(AuthMember.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter methodParameter,
+		ModelAndViewContainer modelAndViewContainer,
+		NativeWebRequest nativeWebRequest,
+		WebDataBinderFactory webDataBinderFactory) {
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)nativeWebRequest.getNativeRequest();
+
+		return resolveAuthMember(httpServletRequest)
+			.orElseThrow(() -> new UnauthorizedException(UNAUTHORIZED_REQUEST));
+	}
+
+	private Optional<AuthMember> resolveAuthMember(HttpServletRequest httpServletRequest) {
+		return getSessionAuthMember(httpServletRequest)
+			.or(this::getJwtAuthMemberFromSecurityContext);
+	}
+
+	private Optional<AuthMember> getSessionAuthMember(HttpServletRequest httpServletRequest) {
+		AuthMember sessionMember = sessionManager.getAuthMember(httpServletRequest);
+		return Optional.ofNullable(sessionMember);
+	}
+
+	private Optional<AuthMember> getJwtAuthMemberFromSecurityContext() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return Optional.empty();
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof AuthMember authMember) {
+			return Optional.of(authMember);
+		}
+
+		return Optional.empty();
+	}
+}

--- a/src/main/java/com/authplayground/global/common/util/SessionManager.java
+++ b/src/main/java/com/authplayground/global/common/util/SessionManager.java
@@ -1,0 +1,33 @@
+package com.authplayground.global.common.util;
+
+import org.springframework.stereotype.Component;
+
+import com.authplayground.api.domain.member.model.AuthMember;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+@Component
+public class SessionManager {
+
+	private static final String LOGIN_MEMBER = "LOGIN_MEMBER";
+
+	public void saveAuthMember(HttpServletRequest httpServletRequest, AuthMember authMember) {
+		httpServletRequest.getSession().setAttribute(LOGIN_MEMBER, authMember);
+	}
+
+	public AuthMember getAuthMember(HttpServletRequest httpServletRequest) {
+		return (AuthMember)httpServletRequest.getSession().getAttribute(LOGIN_MEMBER);
+	}
+
+	public void expiredSession(HttpServletRequest httpServletRequest) {
+		HttpSession httpSession = httpServletRequest.getSession(false);
+		invalidateSession(httpSession);
+	}
+
+	private void invalidateSession(HttpSession httpSession) {
+		if (httpSession != null) {
+			httpSession.invalidate();
+		}
+	}
+}

--- a/src/main/java/com/authplayground/global/config/SecurityConfig.java
+++ b/src/main/java/com/authplayground/global/config/SecurityConfig.java
@@ -50,8 +50,10 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
 		httpSecurity.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
-			.httpBasic(AbstractHttpConfigurer::disable)
-			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
+			.httpBasic(AbstractHttpConfigurer::disable);
+
+		httpSecurity.sessionManagement(session -> session.sessionCreationPolicy(IF_REQUIRED)
+			.sessionFixation().migrateSession());
 
 		httpSecurity.authorizeHttpRequests(auth -> auth
 			.requestMatchers(PUBLIC_API_PATHS).permitAll()

--- a/src/main/java/com/authplayground/global/config/WebConfig.java
+++ b/src/main/java/com/authplayground/global/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.authplayground.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.authplayground.global.auth.AuthMemberArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authMemberArgumentResolver);
+	}
+}

--- a/src/main/java/com/authplayground/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/authplayground/global/error/model/ErrorMessage.java
@@ -17,6 +17,7 @@ public enum ErrorMessage {
 	BLACKLISTED_ACCESS_TOKEN("[❎ ERROR] 블랙리스트에 등록된 액세스 토큰입니다."),
 	UNAUTHORIZED_REFRESH_TOKEN("[❎ ERROR] 유효하지 않은 리프레시 토큰입니다."),
 	MISMATCH_REFRESH_TOKEN("[❎ ERROR] 리프레시 토큰이 일치하지 않습니다."),
+	REUSED_REFRESH_TOKEN("[❎ ERROR] 재사용된 리프레시 토큰 사용을 시도했습니다."),
 
 	// 403 Forbidden
 	NO_PERMISSION_FAILURE("[❎ ERROR] 권한이 없는 사용자가 접근했습니다."),


### PR DESCRIPTION
- JwtAuthenticationFilter에서 인증 성공 시 AuthMember 추출 후 SecurityContextHolder에 등록
- 동시에 세션에 AuthMember가 존재한다면, JWT 검증 없이 바로 세션에서 인증 정보 주입

#### 세션 설정 적용
- sessionCreationPolicy(IF_REQUIRED)로 필요 시에만 세션 생성되도록 설정
- sessionFixation().migrateSession()으로 세션 고정 공격 방지 설정 완료

#### 커스텀 리졸버 구현
- 세션에서 SecurityContext 순으로 인증 정보 조회
- 세션 기반 인증과 JWT 기반 인증을 함께 지원하는 구조로 구현

#### 로그인 시 세션 저장
- 로그인 성공 시 AuthMember를 세션에 캐싱하여 재사용 가능하도록 구현
- LoginResponse를 활용해 TokenResponse와 AuthMember를 함께 응답

#### 로그아웃 시 처리
- AccessToken을 블랙리스트에 등록하여 재사용 방지
- Redis에서 RefreshToken 삭제
- 세션 무효화 처리