### PR TITLE
Swagger 설정 및 API 문서화 적용

### DIFF
--- a/src/main/java/com/authplayground/api/dto/auth/request/LoginRequest.java
+++ b/src/main/java/com/authplayground/api/dto/auth/request/LoginRequest.java
@@ -1,15 +1,18 @@
 package com.authplayground.api.dto.auth.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 public record LoginRequest(
+	@Schema(description = "사용자 이메일", example = "test@example.com")
 	@NotBlank(message = "사용자 이메일을 입력해주세요.")
 	@Email(message = "이메일 형식으로 입력해주세요.")
 	String email,
 
+	@Schema(description = "사용자 비밀번호", example = "password1234!")
 	@NotBlank(message = "사용자 비밀번호를 입력해주세요.")
 	String password
 ) {

--- a/src/main/java/com/authplayground/api/dto/auth/response/LoginResponse.java
+++ b/src/main/java/com/authplayground/api/dto/auth/response/LoginResponse.java
@@ -4,12 +4,17 @@ import com.authplayground.api.domain.member.entity.Member;
 import com.authplayground.api.domain.member.model.AuthMember;
 import com.authplayground.api.dto.token.response.TokenResponse;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+
 @Builder
+@Schema(description = "로그인 응답 DTO")
 public record LoginResponse(
+	@Schema(description = "JWT 액세스 토큰 및 리프레시 토큰")
 	TokenResponse tokenResponse,
 
+	@Schema(description = "인증된 사용자 정보")
 	AuthMember authMember
 ) {
 

--- a/src/main/java/com/authplayground/api/dto/member/request/SignUpRequest.java
+++ b/src/main/java/com/authplayground/api/dto/member/request/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.authplayground.api.dto.member.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,19 +8,24 @@ import lombok.Builder;
 
 @Builder
 public record SignUpRequest(
+	@Schema(description = "사용자 이메일", example = "newuser@example.com")
 	@NotBlank(message = "사용자 이메일을 입력해주세요.")
 	@Email(message = "이메일 형식으로 입력해주세요.")
 	String email,
 
+	@Schema(description = "사용자 비밀번호", example = "securePassword1!")
 	@NotBlank(message = "사용자 비밀번호를 입력해주세요.")
 	String password,
 
+	@Schema(description = "확인용 비밀번호", example = "securePassword1!")
 	@NotBlank(message = "확인 비밀번호를 입력해주세요.")
 	String passwordCheck,
 
+	@Schema(description = "사용자 닉네임", example = "nickname")
 	@NotBlank(message = "사용자 닉네임을 입력해주세요.")
 	String nickname,
 
+	@Schema(description = "주민등록번호", example = "980521-1234567")
 	@NotBlank(message = "사용자 주민등록번호를 입력해주세요.")
 	@Pattern(
 		regexp = "^\\d{6}-[1-4]\\d{6}$",
@@ -27,6 +33,7 @@ public record SignUpRequest(
 	)
 	String registrationNumber,
 
+	@Schema(description = "주소", example = "경기도 구리시 인창동 123")
 	String address
 ) {
 }

--- a/src/main/java/com/authplayground/api/dto/member/request/UpdateRequest.java
+++ b/src/main/java/com/authplayground/api/dto/member/request/UpdateRequest.java
@@ -1,11 +1,14 @@
 package com.authplayground.api.dto.member.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record UpdateRequest(
+	@Schema(description = "변경할 닉네임", example = "newNickname")
 	String nickname,
 
+	@Schema(description = "변경할 주소", example = "서울특별시 종로구 새문안로 100")
 	String address
 ) {
 }

--- a/src/main/java/com/authplayground/api/dto/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/authplayground/api/dto/member/response/MemberInfoResponse.java
@@ -1,13 +1,17 @@
 package com.authplayground.api.dto.member.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record MemberInfoResponse(
+	@Schema(description = "사용자 이메일", example = "user@example.com")
 	String email,
 
+	@Schema(description = "사용자 닉네임", example = "nickname123")
 	String nickname,
 
+	@Schema(description = "사용자 주소", example = "부산광역시 해운대구 APT 101동")
 	String address
 ) {
 }

--- a/src/main/java/com/authplayground/api/dto/token/response/TokenResponse.java
+++ b/src/main/java/com/authplayground/api/dto/token/response/TokenResponse.java
@@ -1,11 +1,14 @@
 package com.authplayground.api.dto.token.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record TokenResponse(
+	@Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	String accessToken,
 
+	@Schema(description = "JWT 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	String refreshToken
 ) {
 }

--- a/src/main/java/com/authplayground/api/presentation/AuthenticationController.java
+++ b/src/main/java/com/authplayground/api/presentation/AuthenticationController.java
@@ -14,6 +14,10 @@ import com.authplayground.api.dto.token.response.TokenResponse;
 import com.authplayground.global.auth.annotation.Auth;
 import com.authplayground.global.common.util.SessionManager;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +25,23 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 APIs", description = "로그인, 로그아웃, 토큰 재발급 기능을 제공합니다.")
 public class AuthenticationController {
 
 	private final SessionManager sessionManager;
 	private final AuthenticationService authenticationService;
 
 	@PostMapping("/login")
+	@Operation(
+		summary = "[로그인] 사용자 인증 및 토큰 발급",
+		description = "사용자의 이메일과 비밀번호를 검증한 뒤, AccessToken과 RefreshToken을 발급합니다. 세션에 사용자 인증 정보를 저장합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 로그인 성공 및 토큰 발급"),
+		@ApiResponse(responseCode = "400", description = "❌ 형식 오류 또는 비밀번호 불일치"),
+		@ApiResponse(responseCode = "404", description = "🔍 존재하지 않는 사용자"),
+		@ApiResponse(responseCode = "500", description = "💥 서버 내부 오류")
+	})
 	public ResponseEntity<TokenResponse> loginMember(
 		@RequestBody @Valid LoginRequest loginRequest,
 		HttpServletRequest httpServletRequest) {
@@ -38,12 +53,31 @@ public class AuthenticationController {
 	}
 
 	@PostMapping("/logout")
+	@Operation(
+		summary = "[로그아웃] 사용자 로그아웃 및 토큰 무효화",
+		description = "현재 인증된 사용자의 액세스 토큰을 블랙리스트에 등록하고, Redis에 저장된 리프레시 토큰을 삭제하며, 세션을 만료시킵니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 로그아웃 성공"),
+		@ApiResponse(responseCode = "401", description = "🔒 인증되지 않은 사용자 요청"),
+		@ApiResponse(responseCode = "500", description = "💥 서버 내부 오류")
+	})
 	public ResponseEntity<String> logoutMember(@Auth AuthMember authMember, HttpServletRequest httpServletRequest) {
 		authenticationService.logoutMember(authMember, httpServletRequest);
 		return ResponseEntity.ok().body("[✅ SUCCESS] 사용자 로그아웃을 성공적으로 완료했습니다.");
 	}
 
 	@PostMapping("/reissue")
+	@Operation(
+		summary = "[토큰 재발급] RefreshToken을 통한 AccessToken 재발급",
+		description = "요청 헤더에 있는 RefreshToken을 검증한 뒤, 새로운 AccessToken과 RefreshToken을 발급합니다. 기존 AccessToken은 블랙리스트에 등록되어 무효화 처리됩니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 토큰 재발급 성공"),
+		@ApiResponse(responseCode = "401", description = "🔒 토큰이 유효하지 않거나 재사용된 경우"),
+		@ApiResponse(responseCode = "404", description = "🔍 존재하지 않는 사용자"),
+		@ApiResponse(responseCode = "500", description = "💥 서버 내부 오류")
+	})
 	public ResponseEntity<TokenResponse> reissueToken(HttpServletRequest httpServletRequest) {
 		return ResponseEntity.ok().body(authenticationService.reissueToken(httpServletRequest));
 	}

--- a/src/main/java/com/authplayground/api/presentation/MemberController.java
+++ b/src/main/java/com/authplayground/api/presentation/MemberController.java
@@ -1,5 +1,6 @@
 package com.authplayground.api.presentation;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.authplayground.api.application.member.MemberService;
@@ -16,28 +18,62 @@ import com.authplayground.api.dto.member.request.UpdateRequest;
 import com.authplayground.api.dto.member.response.MemberInfoResponse;
 import com.authplayground.global.auth.annotation.Auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Tag(name = "회원 APIs", description = "회원가입 및 회원 정보 관리 API")
 public class MemberController {
 
 	private final MemberService memberService;
 
 	@PostMapping("/signup")
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(
+		summary = "[회원가입] 사용자 계정 생성",
+		description = "요청된 사용자 정보를 바탕으로 신규 회원 계정을 생성합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "🎉 회원가입 완료"),
+		@ApiResponse(responseCode = "400", description = "❌ 요청 데이터 형식 오류 또는 비밀번호 불일치"),
+		@ApiResponse(responseCode = "409", description = "⚠️ 중복된 사용자 정보 존재"),
+		@ApiResponse(responseCode = "500", description = "💥 서버 내부 오류 (예: AES 암호화 실패)")
+	})
 	public ResponseEntity<String> signUpMember(@RequestBody @Valid SignUpRequest signUpRequest) {
 		memberService.signUpMember(signUpRequest);
 		return ResponseEntity.ok().body("[✅ SUCCESS] 사용자 정보를 성공적으로 생성했습니다.");
 	}
 
 	@GetMapping
+	@Operation(
+		summary = "[회원정보 조회] 로그인 사용자 정보 확인",
+		description = "인증된 사용자의 이메일, 닉네임, 주소 정보를 조회합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 사용자 정보 조회 성공"),
+		@ApiResponse(responseCode = "401", description = "🔒 인증되지 않은 요청")
+	})
 	public ResponseEntity<MemberInfoResponse> findMemberInfo(@Auth AuthMember authMember) {
 		return ResponseEntity.ok().body(memberService.findMemberInfo(authMember));
 	}
 
 	@PutMapping
+	@Operation(
+		summary = "[회원정보 수정] 사용자 닉네임 및 주소 변경",
+		description = "인증된 사용자의 닉네임 및 주소를 수정합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 사용자 정보 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "❌ 요청 데이터 형식 오류"),
+		@ApiResponse(responseCode = "409", description = "⚠️ 중복된 닉네임"),
+		@ApiResponse(responseCode = "401", description = "🔒 인증되지 않은 요청")
+	})
 	public ResponseEntity<String> updateMember(
 		@Auth AuthMember authMember,
 		@RequestBody @Valid UpdateRequest updateRequest) {
@@ -47,6 +83,15 @@ public class MemberController {
 	}
 
 	@DeleteMapping
+	@Operation(
+		summary = "[회원탈퇴] 사용자 계정 삭제",
+		description = "현재 로그인한 사용자의 계정을 삭제합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "✅ 회원탈퇴 완료"),
+		@ApiResponse(responseCode = "401", description = "🔒 인증되지 않은 요청"),
+		@ApiResponse(responseCode = "500", description = "💥 서버 내부 오류")
+	})
 	public ResponseEntity<String> deleteMember(@Auth AuthMember authMember) {
 		memberService.deleteMember(authMember);
 		return ResponseEntity.ok().body("[✅ SUCCESS] 사용자 정보 삭제를 성공적으로 완료했습니다.");

--- a/src/main/java/com/authplayground/global/common/util/SwaggerConstant.java
+++ b/src/main/java/com/authplayground/global/common/util/SwaggerConstant.java
@@ -1,0 +1,17 @@
+package com.authplayground.global.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SwaggerConstant {
+
+	public static final String API_TITLE = "Auth Playground API Docs";
+	public static final String API_DESCRIPTION = "JWT + 세션 기반 인증 시스템의 API 문서입니다.";
+	public static final String API_VERSION = "1.0.0";
+
+	public static final String SECURITY_SCHEME_NAME = "AccessToken";
+	public static final String SECURITY_SCHEME_DESCRIPTION = "JWT 형식의 Bearer 토큰을 입력하세요";
+	public static final String AUTH_HEADER_NAME = "Authorization";
+	public static final String BEARER_TYPE = "bearer";
+}

--- a/src/main/java/com/authplayground/global/config/SwaggerConfig.java
+++ b/src/main/java/com/authplayground/global/config/SwaggerConfig.java
@@ -1,0 +1,50 @@
+package com.authplayground.global.config;
+
+import static com.authplayground.global.common.util.SwaggerConstant.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.info(apiInfo())
+			.addSecurityItem(securityRequirement())
+			.components(components());
+	}
+
+	private Info apiInfo() {
+		return new Info()
+			.title(API_TITLE)
+			.description(API_DESCRIPTION)
+			.version(API_VERSION);
+	}
+
+	private SecurityRequirement securityRequirement() {
+		return new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+	}
+
+	private Components components() {
+		return new Components()
+			.addSecuritySchemes(SECURITY_SCHEME_NAME, createSecurityScheme());
+	}
+
+	private SecurityScheme createSecurityScheme() {
+		return new SecurityScheme()
+			.name(AUTH_HEADER_NAME)
+			.type(SecurityScheme.Type.HTTP)
+			.scheme(BEARER_TYPE)
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.description(SECURITY_SCHEME_DESCRIPTION);
+	}
+}


### PR DESCRIPTION
JWT + 세션 기반 인증 시스템에 Swagger(OpenAPI 3)를 적용하여 API 문서화를 진행했습니다.

#### SwaggerConfig 설정 클래스 구현
- SecurityScheme을 사용하여 JWT 인증 설정 추가
- OpenAPI 기본 정보(title, description, version) 정의

#### 컨트롤러 별 `@Operation`, `@ApiResponse` 어노테이션 적용
- 회원 관련 엔드포인트 (회원가입, 조회, 수정, 삭제)
- 인증 관련 엔드포인트 (로그인, 로그아웃, 토큰 재발급)

#### DTO 객체에 `@Schema` 어노테이션 적용
- 요청/응답 객체에 필드 설명 및 타입 명시

#### Swagger UI에서 Authorization 헤더를 설정하고 테스트할 수 있도록 구성됨  
- "http://localhost:8080/swagger-ui/index.html" 로 접속 가능
